### PR TITLE
feat: add CVE-2024-23758

### DIFF
--- a/data/2024/CVE-2024-23758.json
+++ b/data/2024/CVE-2024-23758.json
@@ -1,0 +1,21 @@
+{
+  "cve": {
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "cpeMatch": [
+              {
+                "criteria": "cpe:2.3:a:unisys:stealth:*:*:*:*:*:*:*:*",
+                "matchCriteriaId": "e8fbf300-19d3-4076-b588-be92322e5f30",
+                "vulnerable": true
+              }
+            ],
+            "negate": false,
+            "operator": "OR"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
This adds metadata for CVE-2024-23758

This was automatically generated by the Anchore vulnerability-data-tools/cve-text-analyzer

From text: An issue discovered in Unisys Stealth 5.3.062.0 allows attackers to view sensitive information via the Enterprise ManagementInstaller_msi.log file. https://public.support.unisys.com/common/public/vulnerability/NVD_Detail_Rpt.aspx?ID=70 n/a n/a 

With confidence factor: 31.927