### PR TITLE
fix CPE configurations for Calico open source product to be of application type rather than OS

### DIFF
--- a/.snapshot/2022/CVE-2022-28224.json
+++ b/.snapshot/2022/CVE-2022-28224.json
@@ -1,0 +1,47 @@
+{
+  "cve": {
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.11.4",
+                "matchCriteriaId": "4E4832D7-F220-4771-8B01-54327CB11938"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:3.12.0:*:*:*:*:*:*:*",
+                "matchCriteriaId": "C6F8BCF7-776F-4B3B-AE3D-3004DA243527"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.20.5",
+                "matchCriteriaId": "7A57465D-F482-4BF7-9250-B36F91743FD9"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.21.0",
+                "versionEndExcluding": "3.21.5",
+                "matchCriteriaId": "620C1B05-AAF2-4033-9EA9-79ECF60715DD"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.22.0",
+                "versionEndExcluding": "3.22.2",
+                "matchCriteriaId": "865171A1-8726-446C-8545-609E9D154A42"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.snapshot/2023/CVE-2023-41378.json
+++ b/.snapshot/2023/CVE-2023-41378.json
@@ -1,0 +1,55 @@
+{
+  "cve": {
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_cloud:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "18.0.0",
+                "matchCriteriaId": "A6E534E0-9FCF-4160-90F6-6DFBAB1165F1"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.15.4",
+                "matchCriteriaId": "7B645D3E-FB99-4AB0-B0BF-403F946EA426"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.16.0",
+                "versionEndExcluding": "3.16.4",
+                "matchCriteriaId": "8A3C0644-99EA-428F-859E-43465A22185E"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.17.0",
+                "versionEndExcluding": "3.17.2",
+                "matchCriteriaId": "F0CE796B-6EFF-48E1-A0D4-7CF859298289"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.25.2",
+                "matchCriteriaId": "821779B9-B2C8-4055-A279-E3FE3F956E5A"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:o:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.26.0",
+                "versionEndExcluding": "3.26.3",
+                "matchCriteriaId": "9B24AB38-41C0-43F7-9D51-01DFCA7F0A94"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/2022/CVE-2022-28224.json
+++ b/data/2022/CVE-2022-28224.json
@@ -1,0 +1,72 @@
+{
+  "_annotation": {
+    "cve_id": "CVE-2022-28224",
+    "reason": "Correcting CPE configurations for the Calico open source product to be application type rather than os.  It seems the NVD folks got confused by the name calico_os and though it was an operating system.  Also adds in the `projectcalico:calico` version of the CPE as that also has been used to refer to the Calico OSS product",
+    "snapshot": "https://raw.githubusercontent.com/anchore/nvd-data-overrides/main/.snapshot/2022/CVE-2022-28224.json"
+  },
+  "cve": {
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.11.4",
+                "matchCriteriaId": "4E4832D7-F220-4771-8B01-54327CB11938"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:3.12.0:*:*:*:*:*:*:*",
+                "matchCriteriaId": "C6F8BCF7-776F-4B3B-AE3D-3004DA243527"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.20.5",
+                "matchCriteriaId": "7A57465D-F482-4BF7-9250-B36F91743FD9"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.21.0",
+                "versionEndExcluding": "3.21.5",
+                "matchCriteriaId": "620C1B05-AAF2-4033-9EA9-79ECF60715DD"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.22.0",
+                "versionEndExcluding": "3.22.2",
+                "matchCriteriaId": "865171A1-8726-446C-8545-609E9D154A42"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:projectcalico:calico:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.20.5",
+                "matchCriteriaId": "7A57465D-F482-4BF7-9250-B36F91743FD9"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:projectcalico:calico:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.21.0",
+                "versionEndExcluding": "3.21.5",
+                "matchCriteriaId": "620C1B05-AAF2-4033-9EA9-79ECF60715DD"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:projectcalico:calico:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.22.0",
+                "versionEndExcluding": "3.22.2",
+                "matchCriteriaId": "865171A1-8726-446C-8545-609E9D154A42"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/data/2023/CVE-2023-41378.json
+++ b/data/2023/CVE-2023-41378.json
@@ -1,0 +1,73 @@
+{
+  "_annotation": {
+    "cve_id": "CVE-2023-41378",
+    "reason": "Correcting CPE configurations for the Calico open source product to be application type rather than os.  It seems the NVD folks got confused by the name calico_os and though it was an operating system.  Also adds in the `projectcalico:calico` version of the CPE as that also has been used to refer to the Calico OSS product",
+    "snapshot": "https://raw.githubusercontent.com/anchore/nvd-data-overrides/main/.snapshot/2023/CVE-2023-41378.json"
+  },
+  "cve": {
+    "configurations": [
+      {
+        "nodes": [
+          {
+            "operator": "OR",
+            "negate": false,
+            "cpeMatch": [
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_cloud:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "18.0.0",
+                "matchCriteriaId": "A6E534E0-9FCF-4160-90F6-6DFBAB1165F1"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.15.4",
+                "matchCriteriaId": "7B645D3E-FB99-4AB0-B0BF-403F946EA426"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.16.0",
+                "versionEndExcluding": "3.16.4",
+                "matchCriteriaId": "8A3C0644-99EA-428F-859E-43465A22185E"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_enterprise:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.17.0",
+                "versionEndExcluding": "3.17.2",
+                "matchCriteriaId": "F0CE796B-6EFF-48E1-A0D4-7CF859298289"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.25.2",
+                "matchCriteriaId": "821779B9-B2C8-4055-A279-E3FE3F956E5A"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:tigera:calico_os:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.26.0",
+                "versionEndExcluding": "3.26.3",
+                "matchCriteriaId": "9B24AB38-41C0-43F7-9D51-01DFCA7F0A94"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:projectcalico:calico:*:*:*:*:*:*:*:*",
+                "versionEndExcluding": "3.25.2",
+                "matchCriteriaId": "821779B9-B2C8-4055-A279-E3FE3F956E5A"
+              },
+              {
+                "vulnerable": true,
+                "criteria": "cpe:2.3:a:projectcalico:calico:*:*:*:*:*:*:*:*",
+                "versionStartIncluding": "3.26.0",
+                "versionEndExcluding": "3.26.3",
+                "matchCriteriaId": "9B24AB38-41C0-43F7-9D51-01DFCA7F0A94"
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
The NVD analysts seem to have confused the calico open source project with being an operating system (probably due to the product name being interpreted as calico_os), when really this is referring to the Calico Open Source offering as opposed to the Enterprise offering, both of which should be using application type CPEs